### PR TITLE
Remove Player / Clear Session  / Visualización de Juegos en Vivo

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -598,6 +598,36 @@ def matches_info(session_name: str):
             , 'message': 'Session ID does not exist.'
             , 'data': []
         }
+    
+
+@app.post("/game/boards")
+def board_info(session_name : str):
+    _session_path = '../sessions/' + session_name
+    if os.path.exists(_session_path):
+        file_path = _session_path + '/session_variables.json'
+        with open(file_path, 'r') as file:
+            data = json.load(file)
+
+        _boards = []
+        for match in data['current_matches']:
+            game_path = _session_path + '/games/' + match['match_id'] + '.pkl'
+            with open(game_path, 'rb') as f:
+                othello_game = pickle.load(f)
+
+            _boards.append({
+                'match_id' : othello_game.match_id
+                , 'white_player' : othello_game.white_player
+                , 'black_player' : othello_game.black_player
+                , 'board' : othello_game.board
+            })
+
+        return {
+            'status': 200
+            , 'message': 'Boards retrieved successfully.'
+            , 'data': _boards
+        }
+
+        
 
 
 # return {

--- a/api/main.py
+++ b/api/main.py
@@ -545,10 +545,12 @@ def eject_player(session_name : str, player_name : str):
         with open(file_path, 'r') as file:
             data = json.load(file)
 
-        print(data)
+        
         if player_name in data['players']:
             data['players'].remove(player_name)
+            
             data['league'] = [player for player in data['league'] if player['name'] != player_name]
+            print(data)
             with open(file_path, 'w') as file:
                 json.dump(data, file)
 

--- a/api/main.py
+++ b/api/main.py
@@ -617,7 +617,7 @@ def board_info(session_name : str):
                 othello_game = pickle.load(f)
 
             _boards.append({
-                'match_id' : othello_game.match_id
+                'match_id' : othello_game.gameid
                 , 'white_player' : othello_game.white_player
                 , 'black_player' : othello_game.black_player
                 , 'board' : othello_game.board

--- a/api/main.py
+++ b/api/main.py
@@ -632,6 +632,43 @@ def board_info(session_name : str):
             , 'data': _boards
         }
 
+@app.post("/game/clear_scores_and_matches")
+def clear_scores(session_name : str):
+    _session_path = '../sessions/' + session_name
+    if os.path.exists(_session_path):
+        file_path = _session_path + '/session_variables.json'
+        with open(file_path, 'r') as file:
+            data = json.load(file)
+
+        for index, player in enumerate(data['league']):
+            player['wins'] = 0
+            player['draws'] = 0
+            player['losses'] = 0
+            player['points'] = 0
+            data['league'][index] = player
+
+        with open(file_path, 'w') as file:
+            json.dump(data, file)
+
+        #remove all games
+        games_path = _session_path + '/games'
+        for game in os.listdir(games_path):
+            game_path = games_path + '/' + game
+            os.remove(game_path)
+
+        return {
+            'status': 200
+            , 'message': 'Scores cleared successfully.'
+        }
+    else:
+        return {
+            'status': 501
+            , 'message': 'Session ID does not exist.'
+        }
+    
+
+
+
         
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -548,7 +548,7 @@ def eject_player(session_name : str, player_name : str):
         print(data)
         if player_name in data['players']:
             data['players'].remove(player_name)
-
+            data['league'] = [player for player in data['league'] if player['name'] != player_name]
             with open(file_path, 'w') as file:
                 json.dump(data, file)
 

--- a/api/main.py
+++ b/api/main.py
@@ -646,6 +646,8 @@ def clear_scores(session_name : str):
             player['losses'] = 0
             player['points'] = 0
             data['league'][index] = player
+        
+        data['current_matches'] = []
 
         with open(file_path, 'w') as file:
             json.dump(data, file)
@@ -659,6 +661,7 @@ def clear_scores(session_name : str):
         return {
             'status': 200
             , 'message': 'Scores cleared successfully.'
+            , 'data': data['league']
         }
     else:
         return {

--- a/api/main.py
+++ b/api/main.py
@@ -621,6 +621,9 @@ def board_info(session_name : str):
                 , 'white_player' : othello_game.white_player
                 , 'black_player' : othello_game.black_player
                 , 'board' : othello_game.board
+                , 'white_score' : othello_game.score[1]
+                , 'black_score' : othello_game.score[-1]
+                , 'game_over' : othello_game.game_over
             })
 
         return {

--- a/api/othello_game.py
+++ b/api/othello_game.py
@@ -148,6 +148,9 @@ class OthelloGame():
     def strike(self):
         self.strikes[self.current_player] += 1
 
+    def get_board(self):
+        return self.board
+
 if __name__ == '__main__':
     game = OthelloGame('test_game')
     game.display_board()

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -7,8 +7,8 @@ import numpy as np
 import time
 import requests
 
-host = 'http://localhost:8000'
-# host = 'http://ec2-18-224-173-144.us-east-2.compute.amazonaws.com:8000'
+#host = 'http://localhost:8000'
+host = 'http://ec2-34-204-14-38.compute-1.amazonaws.com'
 
 st.session_state.game_id = st.session_state.get('game_id', '')
 st.session_state.game_status = st.session_state.get('game_id', 'new')
@@ -45,7 +45,7 @@ def refresh_classif(game_id):
         st.session_state.classification = []
 
 def remove_player(game_id, player_id):
-    response = requests.post(host + '/session/eject?session_name=' + game_id + '&player_id=' + player_id).json()
+    response = requests.post(host + '/session/eject?session_name=' + game_id + '&player_name=' + player_id).json()
     refresh_classif(game_id)
 #
 # def refresh_matches():
@@ -161,19 +161,32 @@ def display_boards(boards):
         st.table(board)
 
 
+
 st.header("Othello Game Boards")
 
 
+
+
 # Refresh and display the boards every few seconds if a session is active
-if st.session_state.get("session_name"):
-    st.subheader(f"Current Boards for Session: {st.session_state['session_name']}")
-    board_placeholder = st.empty()  # Placeholder to update board state
+# Button to start/stop visualization
+if st.button("Toggle Visualization"):
+    st.session_state['visualize'] = not st.session_state.get('visualize', False)
 
-    while True:
-        boards = get_boards(st.session_state["session_name"])
+# Display boards if visualization is enabled
+if st.session_state.get("visualize", False):
+    st.subheader(f"Current Boards for Session: {st.session_state.game_id}")
+    board_placeholder = st.empty()
 
-        # Clear previous display and render current boards
+    # Run visualization loop
+    while st.session_state['visualize']:
+        boards = get_boards(st.session_state.game_id)
+
         with board_placeholder.container():
             display_boards(boards)
 
-        time.sleep(2)  # Refresh every 2 seconds
+        # Refresh every 2 seconds
+        time.sleep(2)
+
+        # Check if button was clicked again to stop visualization
+        if not st.session_state['visualize']:
+            break

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -154,11 +154,11 @@ def get_boards(session_name):
 def display_boards(boards):
     for board_info in boards:
         st.subheader(f"Match ID: {board_info['match_id']}")
-        st.write(f"White Player: {board_info['white_player']} | Black Player: {board_info['black_player']}")
+        st.write(f"White Player: {board_info['white_player']} - Score: {board_info['white_score']} | Black Player: {board_info['black_player']} - Score: {board_info['black_score']}")
         
         # Convert board to DataFrame and replace values
         board = pd.DataFrame(board_info["board"])
-        board = board.replace({0: ".", 1: "○", -1: "●"})
+        board = board.replace({0: "", -1: "$\Large ○$", 1: "$\Large ● $"})
         
         st.table(board)
 
@@ -181,7 +181,8 @@ if st.session_state.get("visualize", False):
 
     # Run visualization loop
     while st.session_state['visualize']:
-        boards = get_boards(st.session_state.game_id)
+        boards = get_boards(st.session_state.game_id)['data']
+        
 
         with board_placeholder.container():
             display_boards(boards)

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -45,8 +45,57 @@ def refresh_classif(game_id):
         st.session_state.classification = []
 
 def remove_player(game_id, player_id):
-    response = requests.post(host + '/session/eject?session_name=' + game_id + '&player_name=' + player_id).json()
-    refresh_classif(game_id)
+    if game_id == '' :
+        pass
+    elif player_id == '' and game_id != '':
+        st.toast('Empty text input', icon="⚠️")
+    else:
+        response = requests.post(host + '/session/eject?session_name=' + game_id + '&player_name=' + player_id).json()
+        refresh_classif(game_id)
+
+def get_boards(session_name):
+    url = host + '/game/boards?session_name=' + session_name
+    response = requests.post(url)
+    if response.status_code == 200:
+        print(response.json())
+        return response.json()
+
+    else:
+        return []
+    
+def display_boards(boards):
+    for board_info in boards:
+        st.subheader(f"Match ID: {board_info['match_id']}")
+        st.write(f"White Player (⬤): {board_info['white_player']} - Score: {board_info['white_score']} | Black Player (◯): {board_info['black_player']} - Score: {board_info['black_score']}")
+        
+        # Convert board to DataFrame and replace values
+        board = pd.DataFrame(board_info["board"])
+        board = board.replace({0: "", -1: "◯", 1: "⬤"})
+        
+        st.table(board)
+
+def display_boards_side_by_side(boards):
+    cols = st.columns(4)  # Adjust the number of columns here
+    for i, board_info in enumerate(boards):
+        col = cols[i % 4]  # Use modulo to alternate columns
+        with col:
+            if board_info['game_over']:
+                st.subheader(f"Match ID: {board_info['match_id']} 🟢")
+            else:
+                st.subheader(f"Match ID: {board_info['match_id']} 🟡")
+            st.write(f"White Player (⬤): {board_info['white_player']} - Score: {board_info['white_score']}")
+            st.write(f"Black Player (◯): {board_info['black_player']} - Score: {board_info['black_score']}")
+            if board_info['game_over']:
+                if board_info['black_score'] > board_info['white_score']:
+                    st.write(f"¡Winner: {board_info['black_player']} ◯!")
+                else:
+                    st.write(f"¡Winner: {board_info['white_player']} ⬤!")
+            
+            # Convert board to DataFrame and replace values
+            board = pd.DataFrame(board_info["board"])
+            board = board.replace({0: "", -1: "◯", 1: "⬤"})
+            
+            st.table(board)
 #
 # def refresh_matches():
 #     pass
@@ -65,13 +114,15 @@ def remove_player(game_id, player_id):
 # def pair_players():
 #     pair = requests.post(host+ '/game/pair_players?session_name=' + st.session_state.game_id)
 
+st.set_page_config(page_title='Othello Game', page_icon='🎲', layout='wide', initial_sidebar_state='auto')
+
+
+
 _game_id = st.text_input('Enter game id')
 
 start_button =  st.button('Start game', on_click=start_game(_game_id))
 
-_remove_player = st.text_input('Remove player')
 
-remove_button = st.button('Remove player', on_click=remove_player(_game_id, _remove_player))
 
 st.title(f'{st.session_state.game_id}')
 
@@ -79,6 +130,15 @@ col1, col2,col3 = st.columns([4,10,2])
 
 with col1:
     st.subheader('Classification')
+with col2:
+    if st.button('Clear Scores and Matches', key = 'clear_scores'):
+        response = requests.post(host + '/game/clear_scores_and_matches?session_name=' + st.session_state.game_id)
+        if response.status_code == 200:
+            response = response.json()
+            if 'data' in response:
+                st.session_state.classification = response['data']
+            else:
+                st.session_state.classification = []
 with col3:
     if st.button('Refresh', key = 'classif_refresh'):
         response = requests.post(host + '/game/classification?session_name=' + st.session_state.game_id)
@@ -103,6 +163,10 @@ st.dataframe(
         , use_container_width=True
         , hide_index=True
 )
+
+_remove_player = st.text_input('Remove player')
+
+remove_button = st.button('Remove player', on_click=remove_player(_game_id, _remove_player))
 
 st.subheader('Matches')
 
@@ -141,33 +205,7 @@ st.dataframe(
     , hide_index=True
 )
 
-def get_boards(session_name):
-    url = host + '/game/boards?session_name=' + session_name
-    response = requests.post(url)
-    if response.status_code == 200:
-        print(response.json())
-        return response.json()
-
-    else:
-        return []
-    
-def display_boards(boards):
-    for board_info in boards:
-        st.subheader(f"Match ID: {board_info['match_id']}")
-        st.write(f"White Player: {board_info['white_player']} - Score: {board_info['white_score']} | Black Player: {board_info['black_player']} - Score: {board_info['black_score']}")
-        
-        # Convert board to DataFrame and replace values
-        board = pd.DataFrame(board_info["board"])
-        board = board.replace({0: "", -1: "$\Large ○$", 1: "$\Large ● $"})
-        
-        st.table(board)
-
-
-
 st.header("Othello Game Boards")
-
-
-
 
 # Refresh and display the boards every few seconds if a session is active
 # Button to start/stop visualization
@@ -178,17 +216,33 @@ if st.button("Toggle Visualization"):
 if st.session_state.get("visualize", False):
     st.subheader(f"Current Boards for Session: {st.session_state.game_id}")
     board_placeholder = st.empty()
+    # If all games are done, continue the loop but stop refreshing the boards
+    all_done = False
+    boards = get_boards(st.session_state.game_id)['data']
+    with board_placeholder.container():
+        display_boards_side_by_side(boards)
+
 
     # Run visualization loop
     while st.session_state['visualize']:
-        boards = get_boards(st.session_state.game_id)['data']
+        if not all_done:
+            boards = get_boards(st.session_state.game_id)['data']
         
+            with board_placeholder.container():
+                display_boards_side_by_side(boards)
 
-        with board_placeholder.container():
-            display_boards(boards)
+        for board_info in boards:
+            #Check if all games are done
+            if board_info['game_over']:
+                all_done = True
+            else:
+                all_done = False
+                break
+       
 
-        # Refresh every 2 seconds
-        time.sleep(2)
+        # Refresh every second
+        
+        time.sleep(1)
 
         # Check if button was clicked again to stop visualization
         if not st.session_state['visualize']:

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -145,7 +145,9 @@ def get_boards(session_name):
     url = host + '/game/boards?session_name=' + session_name
     response = requests.post(url)
     if response.status_code == 200:
+        print(response.json())
         return response.json()
+
     else:
         return []
     


### PR DESCRIPTION
Se cambio la vista del app para que sea más amplia. 

Se agregó la funcionalidad de limpiar la sesión (clear session) la cual resetea los valores de ganados, perdidos, etc. en la liga y **elimina** los juegos previos de esa sesión  (es decir, elimina los archivos en la capeta de juegos de esa sesión). Ver /game/clear_scores_and_matches en main.py. 

La se agregó la funcionalidad para eliminar a un jugador de una sesión utilizando la llamada existente /session/eject pero cambiondola para que lo elimine también de la liga, no solamente de los jugadores. 

Se implemento la visualización en vivo de los juegos activos, para esto se implemento la llamada /game/boards.